### PR TITLE
fix the saved transformed image

### DIFF
--- a/Browsing Functions/AtlasTransformBrowser.m
+++ b/Browsing Functions/AtlasTransformBrowser.m
@@ -635,11 +635,11 @@ if strcmp(key_letter,'x')
         disp('atlas location saved')
         
         % save transformed histology image
-        current_slice_image = imread(fullfile(save_location, [slice_name '.tif']));
-%         current_slice_image = flip(get(ud_slice.im, 'CData'),1);
-        R = imref2d(size(ud.ref));
-        curr_slice_trans = imwarp(current_slice_image, ud.transform, 'OutputView',R);
-        imwrite(curr_slice_trans, fullfile(folder_transformations, [slice_name '_transformed.tif']))
+%         current_slice_image = imread(fullfile(save_location, [slice_name '.tif']));
+% %         current_slice_image = flip(get(ud_slice.im, 'CData'),1);
+%         R = imref2d(size(ud.ref));
+%         curr_slice_trans = imwarp(current_slice_image, ud.transform, 'OutputView',R);
+        imwrite(ud.curr_slice_trans, fullfile(folder_transformations, [slice_name '_transformed.tif']))
         
         disp('transform saved')
         catch


### PR DESCRIPTION
Hey @philshams it seemed like the wrong image was getting saved out to /processed/transformations/name_transformed.tif. For some reason you were re-doing the imwarp there (in the x-keypress), and I'm not sure exactly what was different about there versus the way you do it above (in the h-keypress) but something was because the saved image wasn't the same as what was displayed. The fix here is just to skip re-computing it and use the one from ud. Making a PR in case you don't think this is correct... 