### PR TITLE
Universalize to non-cortical recordings

### DIFF
--- a/SHARP-Track/Display_Probe_Track.m
+++ b/SHARP-Track/Display_Probe_Track.m
@@ -119,7 +119,7 @@ end
 
 % determine "origin" at top of brain -- step upwards along tract direction until tip of brain / past cortex
 ann = 10;
-isoCtxId = num2str(st.id(strcmp(st.acronym, 'Isocortex')));
+isoCtxId = num2str(st.id(strcmp(st.acronym, 'root')));
 gotToCtx = false;
 while ~(ann==1 && gotToCtx)
     m = m-p; % step 10um, backwards up the track


### PR DESCRIPTION
Use 'root' instead of 'Isocortex' so that the surface of the brain is always found at some point, even for cerebellar (or other) recordings - no offense on our side ;)